### PR TITLE
Changed dependency on i2c-bus to ^5.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/HendrikRoth/node-red-contrib-oled#readme",
   "dependencies": {
-    "i2c-bus": "^1.2.4",
+    "i2c-bus": "^5.1.0",
     "oled-font-5x7": "^1.0.0",
     "oled-i2c-bus": "^1.0.10"
   },


### PR DESCRIPTION
now compiles with node 12.13.1